### PR TITLE
Add "Common workflows" section with two pages (download all data, use data in QGIS)

### DIFF
--- a/docs/reference/common-workflows/download-all-of-your-data/index.md
+++ b/docs/reference/common-workflows/download-all-of-your-data/index.md
@@ -1,0 +1,110 @@
+---
+sidebar_position: 2
+---
+
+# Download all of your data
+
+As part of our commitment to [data sovereignty](/overview/design-principles/#-data-sovereignty-and-control), Guardian Connector provides multiple ways for users to retrieve their project data at any time. This ensures you maintain full control over your data and can export it when needed.
+
+## Why download all of your data?
+
+There are several scenarios where you might want to download all of your data:
+
+- **Project completion**: You're finished with Guardian Connector and want to take your project data with you
+- **Backup**: You want to create a local backup of your data for safekeeping
+- **Migration**: You're planning to move to a different platform or hosting provider
+
+## What data can you download?
+
+Guardian Connector stores different types of data, and the export options vary depending on your needs:
+
+### 📊 **Project Data** (Primary Export Focus)
+- **Tabular data**: Survey responses, spatial data, and other structured data stored in the PostgreSQL warehouse database
+- **Files**: Images, documents, media files, and exported data files stored in persistent storage
+
+### ⚙️ **Configuration Data** (Available via VM Backup only)
+- Guardian Connector Explorer metadata and Superset dashboards
+- Windmill script configurations and scheduled workflows
+- CapRover platform configuration
+- CoMapeo Cloud raw data
+
+## How to download your data
+
+Guardian Connector provides several methods for downloading your data, each suited to different scenarios:
+
+### Method 1: Download via GC Scripts Hub (Recommended)
+
+The most comprehensive approach uses scripts in the [GC Scripts Hub](/reference/gc-toolkit/gc-scripts-hub/) to export your project data:
+
+#### Download Tabular Data
+The `download_all_postgres_data` script exports all project-specific tabular data from the PostgreSQL warehouse database:
+
+- Survey data from KoboToolbox, CoMapeo, and other connectors
+- Manually uploaded tabular data
+- All data is exported as CSV files and compressed into a single ZIP archive
+- Once created, you can download the archive using [Filebrowser](/reference/gc-toolkit/filebrowser/)
+
+#### Download Files (Azure)
+The `download_all_files_azure` script provides secure access to file-based data stored in Azure Blob Storage:
+
+- Generates a secure [SAS (Shared Access Signature) URL](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview) with time-limited access
+- Provides `azcopy` commands for different destinations:
+  - Local disk (download to your computer)
+  - AWS S3 bucket (cloud-to-cloud transfer)
+  - Google Cloud Storage (cloud-to-cloud transfer)
+  - Another Azure Storage account (cloud-to-cloud transfer)
+
+:::tip
+**Advantages of using the `download_all_files_azure` script:**
+- Fast transfers, especially between cloud services
+- Flexible destination options
+- No additional load on your Guardian Connector deployment
+- Resumable transfers if interrupted
+:::
+
+### Method 2: Download via Filebrowser
+
+For smaller datasets, you can use [Filebrowser](/reference/gc-toolkit/filebrowser/) directly:
+
+1. Navigate to Filebrowser in your Guardian Connector instance
+2. Select the files or folders you want to download
+3. Click the "Download" button to generate a ZIP archive
+
+:::note
+This method works well for smaller datasets but may be slow for large collections of files (several gigabytes or more).
+:::
+
+### Method 3: Complete System Backup (Advanced)
+
+For scenarios where you need configuration data or plan to migrate your entire Guardian Connector instance, you can request a complete VM backup from your hosting provider. This includes:
+
+- All project data
+- Configuration settings
+- Platform metadata
+- Service configurations
+
+Contact your Guardian Connector administrator or hosting provider for assistance with this option.
+
+## Important considerations
+
+### ⚠️ Timing your exports
+- Avoid running exports while new data is actively being posted to the warehouse to prevent inconsistent snapshots
+- Schedule exports during periods of low activity
+- Consider running exports after major data collection campaigns are complete
+- Export scripts should be run from within an active Guardian Connector deployment
+
+### 💾 Storage and access
+- Large exports may consume significant disk space
+- Exported files are stored in persistent storage and may not be accessible after Guardian Connector shutdown
+
+## Need help?
+
+If you encounter issues or need assistance with data exports:
+
+- Check the [GC Scripts Hub documentation](/reference/gc-toolkit/gc-scripts-hub/) for detailed script information
+- Contact your Guardian Connector administrator
+
+---
+
+🌀 *This feature is part of Guardian Connector's commitment to **data sovereignty and user control**. Your data belongs to you, and we're committed to making it easy to access and export whenever you need it.*
+

--- a/docs/reference/common-workflows/index.md
+++ b/docs/reference/common-workflows/index.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 4
+---
+
+# Common Workflows
+
+This section provides detailed guides for common workflows when using Guardian Connector.

--- a/docs/reference/common-workflows/index.md
+++ b/docs/reference/common-workflows/index.md
@@ -4,4 +4,14 @@ sidebar_position: 4
 
 # Common Workflows
 
-This section provides detailed guides for common workflows when using Guardian Connector.
+This section provides detailed reference documentation for common workflows when using Guardian Connector.
+
+## What you'll find here
+
+Documentation for accomplishing specific tasks with Guardian Connector, such as:
+
+- Complete data flows from a data collection tool to visualization platforms
+- Working with your data in external tools like QGIS
+- Exporting and backing up your data
+
+Browse the guides in this section to find workflows that match your needs.

--- a/docs/reference/common-workflows/use-your-data-in-qgis/index.md
+++ b/docs/reference/common-workflows/use-your-data-in-qgis/index.md
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+---
+
+# Use your data in QGIS
+
+QGIS is a powerful open-source application for working with geographic data, such as shapefiles, geopackages, data collected using [CoMapeo](/reference/connected-applications/comapeo), and other spatial data formats. It allows you to create, edit, and visualize maps in countless ways. 
+
+You can integrate QGIS with Guardian Connector in two main ways:
+
+1. **Importing data** from Guardian Connector into QGIS for spatial analysis or visualization.
+2. **Exporting processed data** or map outputs from QGIS back into Guardian Connector to enrich your datasets with geographic insights.

--- a/docs/reference/common-workflows/use-your-data-in-qgis/index.md
+++ b/docs/reference/common-workflows/use-your-data-in-qgis/index.md
@@ -4,9 +4,53 @@ sidebar_position: 1
 
 # Use your data in QGIS
 
-QGIS is a powerful open-source application for working with geographic data, such as shapefiles, geopackages, data collected using [CoMapeo](/reference/connected-applications/comapeo), and other spatial data formats. It allows you to create, edit, and visualize maps in countless ways. 
+[QGIS](/reference/recommended-applications/qgis) is a powerful open-source GIS application that can work with spatial data from Guardian Connector. This guide shows you how to download your data and open it in QGIS for analysis and visualization.
 
-You can integrate QGIS with Guardian Connector in two main ways:
+:::tip
+This workflow works with any GIS software, including ArcGIS, QGIS, or other spatial analysis tools. The key is downloading your data as files and opening them in your preferred GIS application.
+:::
 
-1. **Importing data** from Guardian Connector into QGIS for spatial analysis or visualization.
-2. **Exporting processed data** or map outputs from QGIS back into Guardian Connector to enrich your datasets with geographic insights.
+## Overview
+
+Guardian Connector stores spatial data in PostgreSQL databases, but the most user-friendly way to work with this data in QGIS is to download it as files and open them locally. This approach:
+
+- **Keeps data safe**: The warehouse database remains read-only and protected
+- **Simplifies workflows**: No need for SQL knowledge or database connections
+- **Provides flexibility**: Work with your data offline and in familiar file formats
+
+## Download your spatial data
+
+### Method 1: Export as GeoJSON
+
+Use the `postgres_to_geojson` script in the [GC Scripts Hub](/reference/gc-toolkit/gc-scripts-hub/) to export spatial data:
+
+1. **Access GC Scripts Hub**: Navigate to your Guardian Connector instance
+2. **Run the export script**: 
+   - Select the `postgres_to_geojson` script
+   - Choose your database connection
+   - Specify the table containing spatial data
+   - Set the export path (default: `/persistent-storage/datalake/exports`)
+3. **Download the file**: Use [Filebrowser](/reference/gc-toolkit/filebrowser/) to download the generated GeoJSON file
+
+### Method 2: Download via Filebrowser
+
+For existing spatial files already stored in Guardian Connector:
+
+1. **Navigate to Filebrowser**: Access your Guardian Connector file storage
+2. **Locate spatial files**: Look for GeoJSON, Shapefile, or other GIS file formats
+3. **Download files**: Select and download the files you need
+
+## Open data in QGIS
+
+Once you have your spatial data files:
+
+1. **Launch QGIS**: Open QGIS on your computer
+2. **Add vector layer**: 
+   - Go to **Layer** → **Add Layer** → **Add Vector Layer**
+   - Or use the **Add Vector Layer** button in the toolbar
+3. **Select your file**: Browse to and select your downloaded GeoJSON or other spatial file
+4. **Load the data**: Click **Open** to load your Guardian Connector data into QGIS
+
+## Need help?
+
+- **QGIS documentation**: Visit the [official QGIS documentation](https://docs.qgis.org/)

--- a/docs/reference/connected-applications/index.md
+++ b/docs/reference/connected-applications/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # Connected Applications

--- a/docs/reference/gc-toolkit/index.md
+++ b/docs/reference/gc-toolkit/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Guardian Connector Toolkit

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 0
 ---
 
 # Introduction
@@ -35,6 +35,14 @@ Documentation for recommended applications that are useful for common tasks and 
 **What you'll find:**
 - Guidance on using tools that we have found to be useful such as [QGIS](/reference/recommended-applications/qgis) and [OpenRefine](/reference/recommended-applications/openrefine)
 
+### 📚 **[Common Workflows](./common-workflows/)**
+
+Guidance for common workflows when using Guardian Connector.
+
+**What you'll find:**
+- Guidance on how to use your data in [QGIS](/reference/recommended-applications/qgis) or other GIS software
+- Information on how to download all of your data
+
 ### 🔧 **[For Developers](./for-developers/)**
 
 Information for developers interested in contributing to Guardian Connector or building custom integrations.
@@ -44,6 +52,7 @@ Information for developers interested in contributing to Guardian Connector or b
 - Development environment setup
 - Deployment and hosting instructions
 - Contribution guidelines
+
 
 ---
 

--- a/docs/reference/recommended-applications/qgis/index.md
+++ b/docs/reference/recommended-applications/qgis/index.md
@@ -12,3 +12,7 @@ You can integrate QGIS with Guardian Connector in two main ways:
 2. **Exporting processed data** or map outputs from QGIS back into Guardian Connector to enrich your datasets with geographic insights.
 
 This makes QGIS a flexible and community-friendly tool for anyone working with land, territory, and spatial data.
+
+## How to use QGIS with Guardian Connector
+
+Please see the [Use your data in QGIS](/reference/common-workflows/use-your-data-in-qgis/) guide for detailed instructions.


### PR DESCRIPTION
Closes #3. Closes #18.

I went back and forth on whether these should be "Guides" instead of pages in "Reference". But grounded in https://diataxis.fr/, I felt that the content I was creating was still moreso the latter. 

I think we can also add pages for these issues in "Common Workflows":

* #34
* #33
* #36

As I was putting this together, it occurred to me that we sometimes write for different user personas. And maybe one thing we can do is clarify that explicitly at the top of each page. So as to communicate, for example, "this page is intended for a community organization's technical data manager". Could be nice to have a page where we define each, and then refer back to that page for definitions across the platform.

Thoughts welcome! (Both on this latter point, and "Common Workflows")