### PR TITLE
Add a minimal hosting Guardian Connector page

### DIFF
--- a/docs/reference/gc-toolkit/hosting/index.md
+++ b/docs/reference/gc-toolkit/hosting/index.md
@@ -2,6 +2,17 @@
 sidebar_position: 5
 ---
 
-# GC Hosting & Costs
+# Hosting Guardian Connector
 
-🚧 Under construction
+The Guardian Connector stack is deployed on a single virtual machine (cloud or on-prem) using [CapRover](https://caprover.com/). You’ll provision compute, attach file storage, set up authentication, and install the core app stack.
+
+### At a glance
+
+* 🖥️ **Compute** — One VM in your cloud of choice or self-hosted.
+* 📂 **Data warehouse** — Private file storage for media + PostgreSQL database for tabular data.
+* 🔐 **Access control** — Centralized login (Auth0).
+* 📦 **Apps** — Windmill, Superset, Filebrowser, GC Explorer, CoMapeo Remote Archive Server, plus anything else via CapRover.
+
+### Get started
+
+For step-by-step guides (Azure, DigitalOcean, DIY), automated deployment scripts, and CapRover templates, see the deployment repo on GitHub: **[ConservationMetrics/gc-deploy](https://github.com/ConservationMetrics/gc-deploy)**.


### PR DESCRIPTION
Honestly, I don't think we're truly ready to produce some the information requested in #5...

> - Hosting options and requirements (including local hosting)
> - Cost estimates and planning resources
> - Security and data sovereignty considerations

Additionally, I think that things like the following are better off being read directly from `gc-deploy` for the kind of user persona that would actually be self-deploying GC:

> - Cloud infrastructure considerations
> - Installation, maintenance and update procedures
> - Using CapRover

So this PR provides minimally viable copy for the "Hosting" page that largely points the user to the `gc-deploy` repo.

I'm going to say this closes #11, and that we file more targeted issues later (e.g. in 2026) to flesh this out more.