### PR TITLE
Add section to FAQ about other platforms

### DIFF
--- a/docs/overview/faq/index.md
+++ b/docs/overview/faq/index.md
@@ -7,3 +7,18 @@ sidebar_position: 98
 ## How do I use Guardian Connector?
 
 Currently, Guardian Connector is in a research and development phase. We are working with a small number of community organizations to test the platform, gather feedback, and co-create new features. While the tools are open-source and can be self-hosted (see [For Developers](/reference/for-developers)), we are not yet ready to support users that are not partners of [Nia Tero](https://niatero.org/). We hope to be able to support more users in the future, and make it even easier to set up and use Guardian Connector yourself.
+
+## How does Guardian Connector compare to other platforms?
+
+As Guardian Connector is still in research and development, comprehensive comparisons with other platforms are challenging. However, there are other tools that also enable data centralization from many different third-party sources. While they differ significantly in scope, capabilities, and intended audiences from Guardian Connector, some similar platforms include:
+
+- **[Earth Ranger](https://www.earthranger.com/)** — A platform designed for wildlife and protected area management, integrating data from various sources (such as ranger patrols, remote sensors, and wildlife collars) to provide situational awareness and support decision-making in conservation efforts.
+
+- **[Niiwin](https://niiwin.com/)** — A platform focused on Indigenous data management and community engagement, designed to support Indigenous communities in organizing and managing their data.
+
+- **[Sensing Clues](https://www.sensingclues.org/)** — A conservation technology platform that integrates data from multiple sources to support wildlife monitoring, threat detection, and protected area management.
+
+- **[ArcGIS Online](https://www.esri.com/en-us/arcgis/products/arcgis-online/overview)** — A cloud-based geographic information system (GIS) platform that enables users to create, share, and analyze spatial data through interactive maps and applications. It offers tools for data visualization, spatial analysis, and collaboration across a broad range of industries.
+
+What sets Guardian Connector apart are the [design principles](/overview/design-principles) that prioritize [Indigenous data sovereignty](/overview/design-principles/data-sovereignty), free and open-source software, self-hostability, and a focus on Indigenous community ownership. These principles ensure that communities maintain full control over their data, infrastructure, and decision-making processes, and are not locked into requiring to pay for licenses or subscriptions to use the platform. These are fundamental requirements that other platforms do not typically prioritize in the same way.
+


### PR DESCRIPTION
Closes https://github.com/ConservationMetrics/gc-docs/issues/32.

Decided not to do a page -- that is too heavy-handed an approach for this early moment. But an FAQ section addition felt just right.