### PR TITLE
Add GC Landing Page, and user management, documentation

### DIFF
--- a/docs/reference/gc-toolkit/gc-explorer/index.md
+++ b/docs/reference/gc-toolkit/gc-explorer/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 tags: [itu-1, itu-2, itu-3, idm, opu, tsp]
 ---
 

--- a/docs/reference/gc-toolkit/gc-landing-page/index.md
+++ b/docs/reference/gc-toolkit/gc-landing-page/index.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 1
+tags: [itu-1, itu-2, itu-3, idm, opu, tsp]
+---
+
+# GC Landing Page
+
+The Guardian Connector Landing Page is the **home page** for your community's Guardian Connector: the front door you arrive at after signing in. It brings everything together in one place, so you don't need to remember web addresses or hunt around for the right tool.
+
+From the Landing Page you can:
+
+- Open the **services** your community uses (like Explorer, Superset, Windmill, or Filebrowser) with a single click.
+- Learn about the **tools you can use with Guardian Connector** to collect and bring in data (like CoMapeo, KoboToolbox, and more).
+
+## 🔑 Signing In
+
+When you first visit the Landing Page, you may be asked to sign up or sign in. After signing up, a member of your community with administrator access needs to **approve your account** and give you a role before you can see the services. Until that happens, you will not be able to access Guardian Connector.
+
+**What you see on the Landing Page depends on your role.** Different people need different tools, so the page only shows the services you have permission to use. If a service you expect is missing, it may not be turned on for your community, or your role may not include access to it yet — reach out to your community's administrator.
+
+## 🚀 Your Services
+
+These are the Guardian Connector services your community can link to from the Landing Page. Each appears as a card you can click to open it in a new tab.
+
+- **[Explorer](/reference/gc-toolkit/gc-explorer/)**: View your community's data as interactive maps, media galleries, and an alerts dashboard.
+- **[Superset](/reference/gc-toolkit/superset/)**: Build and explore charts, dashboards, and visualizations from your data.
+- **[Filebrowser](/reference/gc-toolkit/filebrowser/)**: Browse, download, and manage your community's raw files and archives.
+- **Windmill**: Run and schedule the automation workflows that gather and process your data (see the [GC Scripts Hub](/reference/gc-toolkit/gc-scripts-hub/)).
+
+Not everyone sees every service. In general, the more advanced or sensitive a tool is, the higher the role needed to open it — for example, Explorer is available to most signed-in users, while Windmill is reserved for administrators.
+
+## 🌐 Tools You Can Use with Guardian Connector
+
+The Landing Page also introduces the field tools and platforms that work with Guardian Connector. These are the apps your community can use to **collect data in the field** — data that then flows into Guardian Connector for viewing and analysis:
+
+- **[CoMapeo](/reference/connected-applications/comapeo/)**: Offline-first mapping and monitoring on a mobile device.
+- **[KoboToolbox](/reference/connected-applications/kobotoolbox/)** and **ODK**: Forms and surveys that work online and offline.
+- **[Timelapse](/reference/connected-applications/timelapse/)**: Reviewing and annotating camera trap images for biodiversity monitoring.
+
+Guardian Connector also connects with other tools such as **ArcGIS Survey123**, **Locus Map**, **Global Forest Watch**, **SMART**, and more. To learn about everything that can be connected, see the [GC Scripts Hub](/reference/gc-toolkit/gc-scripts-hub/).
+
+## 👥 User Management (for Administrators)
+
+If you are an **administrator**, the Landing Page gives you a User Management area to control who can access your community's Guardian Connector and what they can do.
+
+From here you can:
+
+- **Search** for people by name or email.
+- See each person's **status** — whether their account is *Approved* or still *Pending* — along with their role and when they last signed in.
+- **Approve (or un-approve) an account.** Only approved users can reach the services.
+- **Assign a role** that decides which services each person can open.
+- **Delete an account** if they should no longer have access.
+
+The currently available roles, from least to most access, are:
+
+- **Signed In**: Signed in, but without access to services yet.
+- **Guest**: Limited access, suitable for visitors or partners.
+- **Member**: Everyday access for community members.
+- **Admin**: Full access, including this User Management area.
+
+When you approve someone and give them the right role, the services they're allowed to use will appear on their Landing Page the next time they sign in.

--- a/docs/reference/gc-toolkit/gc-scripts-hub/index.md
+++ b/docs/reference/gc-toolkit/gc-scripts-hub/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 tags: [opu, tsp]
 ---
 

--- a/docs/reference/gc-toolkit/superset/index.md
+++ b/docs/reference/gc-toolkit/superset/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 tags: [itu-1, itu-2, itu-3, idm, opu, tsp]
 ---
 


### PR DESCRIPTION
Closes https://github.com/ConservationMetrics/gc-docs/issues/80. Documents the landing page as a whole plus user management.